### PR TITLE
fix: adding a missing path for Chrome Canary on Windows

### DIFF
--- a/core/src/commonMain/kotlin/dev/kdriver/core/browser/Config.kt
+++ b/core/src/commonMain/kotlin/dev/kdriver/core/browser/Config.kt
@@ -203,7 +203,8 @@ class Config(
                 val subPaths = listOf(
                     "Google/Chrome/Application",
                     "Google/Chrome Beta/Application",
-                    "Google/Chrome Canary/Application"
+                    "Google/Chrome Canary/Application",
+                    "Google/Chrome SxS/Application",
                 )
                 for (base in programFiles) {
                     for (sub in subPaths) {


### PR DESCRIPTION
Fix #1 