### PR TITLE
feat: batch expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To use kdriver, add the following to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.kdriver:core:0.2.10")
+    implementation("dev.kdriver:core:0.2.11")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 allprojects {
     group = "dev.kdriver"
-    version = "0.2.10"
+    version = "0.2.11"
     project.ext.set("url", "https://github.com/cdpdriver/kdriver")
     project.ext.set("license.name", "Apache 2.0")
     project.ext.set("license.url", "https://www.apache.org/licenses/LICENSE-2.0.txt")

--- a/core/src/commonMain/kotlin/dev/kdriver/core/network/BaseBatchRequestExpectation.kt
+++ b/core/src/commonMain/kotlin/dev/kdriver/core/network/BaseBatchRequestExpectation.kt
@@ -1,0 +1,24 @@
+package dev.kdriver.core.network
+
+import dev.kdriver.core.tab.Tab
+
+/**
+ * Batch expectation built on top of BaseRequestExpectation instances.
+ */
+class BaseBatchRequestExpectation(
+    tab: Tab,
+    urlPatterns: List<Regex>,
+) : BatchRequestExpectation {
+
+    override val expectations: Map<Regex, RequestExpectation> =
+        urlPatterns.associateWith { pattern -> BaseRequestExpectation(tab, pattern) }
+
+    override suspend fun <T> use(block: suspend BatchRequestExpectation.() -> T): T {
+        val exps = expectations.values.toList()
+        suspend fun <T> nest(index: Int, run: suspend BatchRequestExpectation.() -> T): T {
+            return if (index >= exps.size) run(this) else exps[index].use { nest(index + 1, run) }
+        }
+        return nest(0, block)
+    }
+
+}

--- a/core/src/commonMain/kotlin/dev/kdriver/core/network/BatchRequestExpectation.kt
+++ b/core/src/commonMain/kotlin/dev/kdriver/core/network/BatchRequestExpectation.kt
@@ -1,0 +1,19 @@
+package dev.kdriver.core.network
+
+/**
+ * Represents a batch of request expectations, each defined by a URL pattern and its corresponding expectation.
+ */
+interface BatchRequestExpectation {
+
+    /**
+     * A map of URL patterns (as [Regex]) to their corresponding [RequestExpectation]s.
+     */
+    val expectations: Map<Regex, RequestExpectation>
+
+    /**
+     * Activate all expectations for the duration of [block]. Expectations are enabled concurrently
+     * by nesting RequestExpectation.use calls, so all handlers are active while [block] executes.
+     */
+    suspend fun <T> use(block: suspend BatchRequestExpectation.() -> T): T
+
+}

--- a/core/src/commonMain/kotlin/dev/kdriver/core/tab/DefaultTab.kt
+++ b/core/src/commonMain/kotlin/dev/kdriver/core/tab/DefaultTab.kt
@@ -11,10 +11,7 @@ import dev.kdriver.core.dom.NodeOrElement
 import dev.kdriver.core.exceptions.EvaluateException
 import dev.kdriver.core.exceptions.TimeoutWaitingForElementException
 import dev.kdriver.core.exceptions.TimeoutWaitingForReadyStateException
-import dev.kdriver.core.network.BaseFetchInterception
-import dev.kdriver.core.network.BaseRequestExpectation
-import dev.kdriver.core.network.FetchInterception
-import dev.kdriver.core.network.RequestExpectation
+import dev.kdriver.core.network.*
 import dev.kdriver.core.utils.filterRecurse
 import io.ktor.http.*
 import io.ktor.util.logging.*
@@ -574,8 +571,18 @@ open class DefaultTab(
         // displays for a short time a red dot on the element
     }
 
-    override suspend fun <T> expect(urlPattern: Regex, block: suspend RequestExpectation.() -> T): T {
+    override suspend fun <T> expect(
+        urlPattern: Regex,
+        block: suspend RequestExpectation.() -> T,
+    ): T {
         return BaseRequestExpectation(this, urlPattern).use(block)
+    }
+
+    override suspend fun <T> expectBatch(
+        urlPatterns: List<Regex>,
+        block: suspend BatchRequestExpectation.() -> T,
+    ): T {
+        return BaseBatchRequestExpectation(this, urlPatterns).use(block)
     }
 
     override suspend fun <T> intercept(

--- a/core/src/commonMain/kotlin/dev/kdriver/core/tab/Tab.kt
+++ b/core/src/commonMain/kotlin/dev/kdriver/core/tab/Tab.kt
@@ -8,6 +8,7 @@ import dev.kdriver.core.dom.Element
 import dev.kdriver.core.dom.NodeOrElement
 import dev.kdriver.core.exceptions.TimeoutWaitingForElementException
 import dev.kdriver.core.exceptions.TimeoutWaitingForReadyStateException
+import dev.kdriver.core.network.BatchRequestExpectation
 import dev.kdriver.core.network.FetchInterception
 import dev.kdriver.core.network.RequestExpectation
 import kotlinx.io.files.Path
@@ -424,7 +425,22 @@ interface Tab : Connection {
      * @param urlPattern The regex pattern to match the request URL.
      * @param block The block to execute during which the expectation is active.
      */
-    suspend fun <T> expect(urlPattern: Regex, block: suspend RequestExpectation.() -> T): T
+    suspend fun <T> expect(
+        urlPattern: Regex,
+        block: suspend RequestExpectation.() -> T,
+    ): T
+
+    /**
+     * Expects multiple requests matching the given list of [urlPatterns].
+     * All expectations are active concurrently during [block].
+     *
+     * @param urlPatterns List of regex patterns to match request URLs.
+     * @param block The block to execute during which the expectations are active.
+     */
+    suspend fun <T> expectBatch(
+        urlPatterns: List<Regex>,
+        block: suspend BatchRequestExpectation.() -> T,
+    ): T
 
     /**
      * Intercepts network requests matching the given [urlPattern] and [requestStage].

--- a/docs/home/quickstart.md
+++ b/docs/home/quickstart.md
@@ -12,7 +12,7 @@ To install, add the dependency to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.kdriver:core:0.2.10")
+    implementation("dev.kdriver:core:0.2.11")
 }
 ```
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,7 +23,7 @@ dependencyResolutionManagement {
             plugin("maven", "com.vanniktech.maven.publish").version("0.30.0")
 
             // Kaccelero
-            version("kaccelero", "0.6.4")
+            version("kaccelero", "0.6.6")
             library("kaccelero-core", "dev.kaccelero", "core").versionRef("kaccelero")
 
             // Ktor


### PR DESCRIPTION
Example: (from tests)

```kotlin
fun main() = runBlocking {
    val browser = createBrowser(this, headless = true, sandbox = false)
    val tab = browser.mainTab ?: error("Main tab is not available")

    val pagePattern = Regex("profile.html")
    val apiPattern = Regex("user-data.json")

    tab.expectBatch(listOf(pagePattern, apiPattern)) {
        tab.get(sampleFile("profile.html"))

        val pageExp = expectations[pagePattern] ?: error("Missing expectation for profile.html")
        val apiExp = expectations[apiPattern] ?: error("Missing expectation for user-data.json")

        val pageResponse = withTimeout(3000L) { pageExp.getResponse() }
        val apiResponse = withTimeout(3000L) { apiExp.getResponse() }

        assertEquals(200, pageResponse.status)
        assertEquals(200, apiResponse.status)

        val userData = withTimeout(3000L) { apiExp.getResponseBody<UserData>() }
        assertEquals("Zendriver", userData.name)
    }

    browser.stop()
}
```