### PR TITLE
Expose CDP on 0.0.0.0 for network access

### DIFF
--- a/core/src/commonMain/kotlin/dev/kdriver/core/browser/DefaultBrowser.kt
+++ b/core/src/commonMain/kotlin/dev/kdriver/core/browser/DefaultBrowser.kt
@@ -147,7 +147,7 @@ open class DefaultBrowser(
         val connectExisting = config.host != null && config.port != null
 
         if (!connectExisting) {
-            config.host = "127.0.0.1"
+            config.host = "0.0.0.0"
             config.port = freePort()
         }
 
@@ -175,7 +175,7 @@ open class DefaultBrowser(
         }
 
         logger.info("Browser process started with PID: ${process?.pid()}")
-        http = HTTPApi(config.host ?: "127.0.0.1", config.port ?: error("Port not set"))
+        http = HTTPApi(config.host ?: "0.0.0.0", config.port ?: error("Port not set"))
 
         delay(config.browserConnectionTimeout)
         repeat(config.browserConnectionMaxTries) {

--- a/core/src/commonMain/kotlin/dev/kdriver/core/browser/Extensions.kt
+++ b/core/src/commonMain/kotlin/dev/kdriver/core/browser/Extensions.kt
@@ -18,7 +18,7 @@ import kotlinx.io.files.Path
  * @param browserArgs Optional list of additional arguments to pass to the browser executable.
  * @param sandbox If true, the browser will run in a sandboxed environment. Defaults to true.
  * @param lang The language to use for the browser.
- * @param host Optional host address for the browser connection. If not provided, defaults to "127.0.0.1".
+ * @param host Optional host address for the browser connection. If not provided, defaults to "0.0.0.0".
  * @param port Optional port for the browser connection. If not provided, a free port will be assigned.
  *
  * @return A new instance of the Browser class.


### PR DESCRIPTION
## Summary
- Change default Chrome DevTools Protocol debug host from `127.0.0.1` to `0.0.0.0` so Chrome listens on all network interfaces
- Enables remote CDP connections from other machines on the same network

## Why
When running Chrome in a VM or container, the CDP debug port is only accessible from localhost. Binding to `0.0.0.0` allows tools on the same private network to connect to Chrome for automation, monitoring, or screenshots via `Page.captureScreenshot`.

## What changed
- `DefaultBrowser.kt`: Changed default host from `127.0.0.1` to `0.0.0.0` (both the config assignment and the HTTPApi fallback)
- `Extensions.kt`: Updated KDoc to reflect the new default

## Security
- Users on private/trusted networks benefit from remote CDP access
- The `freePort()` functions still bind to `127.0.0.1` for port discovery only
- Users can still explicitly set `config.host = "127.0.0.1"` to restrict access

## Test plan
- [x] JVM compilation passes
- [x] JVM tests pass