### PR TITLE
Delegate OpenTelemetryTab.targetInfo to the wrapped tab

### DIFF
--- a/opentelemetry/src/commonMain/kotlin/dev/kdriver/opentelemetry/OpenTelemetryTab.kt
+++ b/opentelemetry/src/commonMain/kotlin/dev/kdriver/opentelemetry/OpenTelemetryTab.kt
@@ -413,7 +413,11 @@ class OpenTelemetryTab(
 
     override suspend fun sleep(t: Long) = tab.sleep(t)
 
-    override var targetInfo: Target.TargetInfo? = tab.targetInfo
+    override var targetInfo: Target.TargetInfo?
+        get() = tab.targetInfo
+        set(value) {
+            tab.targetInfo = value
+        }
 
     @InternalCdpApi
     override val events: Flow<Message.Event> = tab.events

--- a/opentelemetry/src/jvmTest/kotlin/dev/kdriver/opentelemetry/OpenTelemetryTabTargetInfoTest.kt
+++ b/opentelemetry/src/jvmTest/kotlin/dev/kdriver/opentelemetry/OpenTelemetryTabTargetInfoTest.kt
@@ -1,0 +1,76 @@
+package dev.kdriver.opentelemetry
+
+import dev.kdriver.cdp.domain.Target
+import dev.kdriver.core.tab.Tab
+import io.mockk.every
+import io.mockk.mockk
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.extension.RegisterExtension
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Guards that [OpenTelemetryTab.targetInfo] delegates to the wrapped tab rather than capturing a
+ * one-time snapshot at construction (audit ISSUE-12).
+ *
+ * The buggy implementation declared `override var targetInfo = tab.targetInfo`, a stored property
+ * initialized once. As a result a traced tab kept reporting stale target info after navigation, and
+ * writes to it never reached the underlying tab — unlike `lastMouseX`/`lastMouseY`, which delegate.
+ */
+class OpenTelemetryTabTargetInfoTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val otelTesting = OpenTelemetryExtension.create()
+    }
+
+    private fun info(url: String) = Target.TargetInfo(
+        targetId = "t",
+        type = "page",
+        title = "",
+        url = url,
+        attached = true,
+        canAccessOpener = false,
+    )
+
+    @Test
+    fun `targetInfo getter reflects updates to the wrapped tab`() = runTest {
+        val tracer = otelTesting.openTelemetry.getTracer("test")
+        var backing: Target.TargetInfo? = info("about:blank")
+        val mockTab = mockk<Tab>(relaxed = true)
+        every { mockTab.targetInfo } answers { backing }
+
+        // Construction must not freeze a snapshot.
+        val traced = mockTab.withTracing(tracer)
+
+        // The underlying tab navigates after the wrapper was created.
+        backing = info("https://example.com")
+
+        assertEquals(
+            "https://example.com",
+            traced.targetInfo?.url,
+            "targetInfo should reflect the current value of the wrapped tab, not a snapshot",
+        )
+    }
+
+    @Test
+    fun `targetInfo setter propagates to the wrapped tab`() = runTest {
+        val tracer = otelTesting.openTelemetry.getTracer("test")
+        var backing: Target.TargetInfo? = info("about:blank")
+        val mockTab = mockk<Tab>(relaxed = true)
+        every { mockTab.targetInfo } answers { backing }
+        every { mockTab.targetInfo = any() } answers { backing = firstArg() }
+
+        val traced = mockTab.withTracing(tracer)
+
+        traced.targetInfo = info("https://example.com")
+
+        assertEquals(
+            "https://example.com",
+            backing?.url,
+            "Writing targetInfo on the wrapper should propagate to the wrapped tab",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

`OpenTelemetryTab.targetInfo` was declared as `override var targetInfo = tab.targetInfo` — a stored property initialized **once** at construction. So a traced tab kept reporting **stale** target info after navigation (the wrapped tab's `targetInfo` updates via events / `updateTarget()` were never reflected), and **writes** to the wrapper never reached the underlying tab.

This affected every `targetId`/`url`/`type` read on a traced tab — `activate`, `getWindow`, `saveScreenshot` filename, `getAllUrls`, and `screenshotB64`'s `wait()`→`updateTarget()` (which updated the wrong object).

## Fix

Delegate get/set onto the wrapped tab, matching the existing `lastMouseX`/`lastMouseY` pattern:

```kotlin
override var targetInfo: Target.TargetInfo?
    get() = tab.targetInfo
    set(value) { tab.targetInfo = value }
```

## Verification (red → green)

Added `OpenTelemetryTabTargetInfoTest` (mockk `Tab` with a mutable backing `targetInfo`, no browser):

- **getter** test: mutate the underlying value *after* wrapping → wrapper must reflect it (not a snapshot).
- **setter** test: write through the wrapper → must propagate to the wrapped tab.

Both **fail** on the snapshot implementation and **pass** after the fix. Full `:opentelemetry:jvmTest` passes.

## Test plan

- [x] `./gradlew :opentelemetry:jvmTest --tests "*.OpenTelemetryTabTargetInfoTest"` — red on unfixed code, green after fix
- [x] `./gradlew :opentelemetry:jvmTest` — all pass