### PR TITLE
feat: add Tab getLocalStorage/setLocalStorage/clearLocalStorage

### DIFF
--- a/cdp-generate/src/main/kotlin/dev/kdriver/cdp/generate/CdpGeneratePlugin.kt
+++ b/cdp-generate/src/main/kotlin/dev/kdriver/cdp/generate/CdpGeneratePlugin.kt
@@ -41,6 +41,7 @@ class CdpGeneratePlugin : Plugin<Project> {
                                 type = type["type"] as String,
                                 description = type["description"] as String?,
                                 enum = (type["enum"] as List<String>?) ?: emptyList(),
+                                items = (type["items"] as Map<String, String>?) ?: emptyMap(),
                                 properties = (type["properties"] as List<Map<String, *>>?)?.map { property ->
                                     Domain.Type.Property(
                                         name = property["name"] as String,

--- a/cdp-generate/src/main/kotlin/dev/kdriver/cdp/generate/Domain.kt
+++ b/cdp-generate/src/main/kotlin/dev/kdriver/cdp/generate/Domain.kt
@@ -15,6 +15,7 @@ class Domain(
         val enum: List<String>,
         val description: String?,
         val properties: List<Property>,
+        override val items: Map<String, String>,
     ) : CanBeTypeAlias {
         class Property(
             val name: String,
@@ -73,10 +74,15 @@ class Domain(
 
     interface CanBeTypeAlias {
         val type: String?
+
+        /**
+         * Element descriptor when [type] is `array`, either `{"type": "..."}` or `{"$ref": "..."}`.
+         * Empty for every other type.
+         */
+        val items: Map<String, String>
     }
 
     interface TypeOrReference : CanBeTypeAlias {
-        val items: Map<String, String>
         val ref: String?
         val optional: Boolean
     }

--- a/cdp-generate/src/main/kotlin/dev/kdriver/cdp/generate/Poetize.kt
+++ b/cdp-generate/src/main/kotlin/dev/kdriver/cdp/generate/Poetize.kt
@@ -151,7 +151,34 @@ fun List<Domain>.resolveRef(refName: String, parentDomain: Domain): Pair<Domain,
     }
 }
 
-fun Domain.CanBeTypeAlias.jsTypeToKType(): TypeName {
+/**
+ * Resolves the element type of an `array`, from its `items` descriptor.
+ *
+ * Shared by both [jsTypeToKType] overloads so a top-level type alias and a property describing the
+ * same array cannot end up with different element types.
+ */
+fun Domain.CanBeTypeAlias.itemsToKType(parentDomain: Domain, domains: List<Domain>): TypeName {
+    if (items.containsKey("\$ref")) {
+        val referenceName = items["\$ref"]
+        return object : Domain.TypeOrReference {
+            override val ref: String? = referenceName
+            override val items: Map<String, String> = emptyMap()
+            override val optional: Boolean = false
+            override val type: String? = null
+        }.resolveType(parentDomain, domains)
+    }
+    return when (items["type"]) {
+        "string" -> STRING
+        "integer" -> INT
+        "number" -> DOUBLE
+        "boolean" -> BOOLEAN
+        "any" -> JSONELEMENT
+        "object" -> MAP.parameterizedBy(STRING, JSONELEMENT)
+        else -> error("Unknown type in ${parentDomain.domain} $items")
+    }
+}
+
+fun Domain.CanBeTypeAlias.jsTypeToKType(parentDomain: Domain, domains: List<Domain>): TypeName {
     return when (type!!) {
         "number" -> DOUBLE
         "string" -> STRING
@@ -159,7 +186,7 @@ fun Domain.CanBeTypeAlias.jsTypeToKType(): TypeName {
         "boolean" -> BOOLEAN
         "any" -> JSONELEMENT
         "object" -> MAP.parameterizedBy(STRING, JSONELEMENT)
-        "array" -> LIST.parameterizedBy(DOUBLE)
+        "array" -> LIST.parameterizedBy(itemsToKType(parentDomain, domains))
         else -> error("Could not interprete type for $this $type")
     }
 }
@@ -170,28 +197,7 @@ fun Domain.TypeOrReference.jsTypeToKType(parentDomain: Domain, domains: List<Dom
         "string" -> STRING
         "integer" -> INT
         "boolean" -> BOOLEAN
-        "array" -> if (items.containsKey("\$ref")) {
-            val referenceName = items["\$ref"]
-            val className = object : Domain.TypeOrReference {
-                override val ref: String? = referenceName
-                override val items: Map<String, String> = emptyMap()
-                override val optional: Boolean = false
-                override val type: String? = null
-            }.resolveType(parentDomain, domains)
-            LIST.parameterizedBy(className)
-        } else {
-            LIST.parameterizedBy(
-                when (items["type"]) {
-                    "string" -> STRING
-                    "integer" -> INT
-                    "number" -> DOUBLE
-                    "any" -> JSONELEMENT
-                    "object" -> MAP.parameterizedBy(STRING, JSONELEMENT)
-                    else -> error("Unknown type in ${parentDomain.domain} $items")
-                }
-            )
-        }
-
+        "array" -> LIST.parameterizedBy(itemsToKType(parentDomain, domains))
         "any" -> JSONELEMENT
         "object" -> MAP.parameterizedBy(STRING, JSONELEMENT)
         else -> error("Could not interprete type for ${parentDomain.domain} $type")
@@ -208,7 +214,9 @@ fun Domain.TypeOrReference.resolveType(parentDomain: Domain, domains: List<Domai
                 ClassName(PACKAGE_NAME, domain.domain).nestedClass(type.id)
             }
         } else {
-            type.jsTypeToKType()
+            // Resolve against the domain the type was found in, not the referring one, so that a
+            // `$ref` inside its `items` points at the right domain.
+            type.jsTypeToKType(domain, domains)
         }
     } else {
         jsTypeToKType(parentDomain, domains)

--- a/cdp/src/commonMain/kotlin/dev/kdriver/cdp/domain/DOMSnapshot.kt
+++ b/cdp/src/commonMain/kotlin/dev/kdriver/cdp/domain/DOMSnapshot.kt
@@ -452,7 +452,7 @@ public class DOMSnapshot(
         /**
          * Attributes of an `Element` node. Flatten name, value pairs.
          */
-        public val attributes: List<List<Double>>? = null,
+        public val attributes: List<List<Int>>? = null,
         /**
          * Only set for textarea elements, contains the text value.
          */
@@ -510,7 +510,7 @@ public class DOMSnapshot(
         /**
          * Array of indexes specifying computed style strings, filtered according to the `computedStyles` parameter passed to `captureSnapshot`.
          */
-        public val styles: List<List<Double>>,
+        public val styles: List<List<Int>>,
         /**
          * The absolute position bounding box.
          */

--- a/cdp/src/commonMain/kotlin/dev/kdriver/cdp/domain/DOMStorage.kt
+++ b/cdp/src/commonMain/kotlin/dev/kdriver/cdp/domain/DOMStorage.kt
@@ -198,7 +198,7 @@ public class DOMStorage(
 
     @Serializable
     public data class GetDOMStorageItemsReturn(
-        public val entries: List<List<Double>>,
+        public val entries: List<List<String>>,
     )
 
     @Serializable

--- a/core/src/commonMain/kotlin/dev/kdriver/core/tab/DefaultTab.kt
+++ b/core/src/commonMain/kotlin/dev/kdriver/core/tab/DefaultTab.kt
@@ -19,6 +19,9 @@ import io.ktor.util.logging.*
 import io.ktor.utils.io.core.*
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
@@ -136,6 +139,42 @@ open class DefaultTab(
     override suspend fun getContent(): String {
         val doc = dom.getDocument(depth = -1, pierce = true)
         return dom.getOuterHTML(backendNodeId = doc.root.backendNodeId).outerHTML
+    }
+
+    /**
+     * Local storage is partitioned per origin, so every call has to name the origin of the page
+     * currently loaded rather than its full URL.
+     */
+    private fun localStorageId(): DOMStorage.StorageId {
+        val url = targetInfo?.url ?: error("target is null")
+        return DOMStorage.StorageId(
+            securityOrigin = Url(url).protocolWithAuthority,
+            isLocalStorage = true,
+        )
+    }
+
+    override suspend fun getLocalStorage(): Map<String, String> {
+        // Each entry comes back as a two-element [key, value] array.
+        return dOMStorage.getDOMStorageItems(localStorageId()).entries
+            .mapNotNull { entry ->
+                val key = entry.getOrNull(0) ?: return@mapNotNull null
+                key to entry.getOrElse(1) { "" }
+            }
+            .toMap()
+    }
+
+    override suspend fun setLocalStorage(items: Map<String, String>) {
+        if (items.isEmpty()) return
+        val storageId = localStorageId()
+        coroutineScope {
+            items.map { (key, value) ->
+                async { dOMStorage.setDOMStorageItem(storageId, key, value) }
+            }.awaitAll()
+        }
+    }
+
+    override suspend fun clearLocalStorage() {
+        dOMStorage.clear(localStorageId())
     }
 
     override suspend fun activate() {

--- a/core/src/commonMain/kotlin/dev/kdriver/core/tab/Tab.kt
+++ b/core/src/commonMain/kotlin/dev/kdriver/core/tab/Tab.kt
@@ -127,6 +127,37 @@ interface Tab : Connection {
     suspend fun getContent(): String
 
     /**
+     * Gets the local storage of the page currently loaded in this tab.
+     *
+     * Values are returned exactly as the browser stores them, that is as strings. Anything that was
+     * serialized before being stored has to be deserialized by the caller.
+     *
+     * @return The local storage entries, keyed by their storage key. Empty if the origin has none.
+     *
+     * @throws IllegalStateException if the tab has no target, so no origin to read from.
+     */
+    suspend fun getLocalStorage(): Map<String, String>
+
+    /**
+     * Sets entries in the local storage of the page currently loaded in this tab.
+     *
+     * Existing keys are overwritten, keys that are absent from [items] are left untouched. Use
+     * [clearLocalStorage] to empty the storage instead.
+     *
+     * @param items The entries to write. Both keys and values are stored as strings.
+     *
+     * @throws IllegalStateException if the tab has no target, so no origin to write to.
+     */
+    suspend fun setLocalStorage(items: Map<String, String>)
+
+    /**
+     * Removes every entry from the local storage of the page currently loaded in this tab.
+     *
+     * @throws IllegalStateException if the tab has no target, so no origin to clear.
+     */
+    suspend fun clearLocalStorage()
+
+    /**
      * Activates the tab, bringing it to the foreground.
      *
      * This method uses the target's ID to activate the target in the browser.

--- a/core/src/jvmTest/kotlin/dev/kdriver/core/tab/TabTest.kt
+++ b/core/src/jvmTest/kotlin/dev/kdriver/core/tab/TabTest.kt
@@ -458,6 +458,67 @@ class TabTest {
         browser.stop()
     }
 
+    // Local Storage Tests
+
+    @Test
+    fun testSetAndGetLocalStorage() = runBlocking {
+        val browser = createBrowser(this, headless = true, sandbox = false)
+        val tab = browser.get(sampleFile("groceries.html"))
+        tab.waitForReadyState(ReadyState.COMPLETE)
+
+        tab.setLocalStorage(mapOf("token" to "abc123", "theme" to "dark"))
+
+        assertEquals(mapOf("token" to "abc123", "theme" to "dark"), tab.getLocalStorage())
+
+        // Cross-check against the page itself, so the test also proves we targeted the right origin
+        // rather than merely reading back what we wrote into some other storage area.
+        assertEquals("abc123", tab.evaluate<String>("window.localStorage.getItem('token')"))
+
+        browser.stop()
+    }
+
+    @Test
+    fun testSetLocalStorageOverwritesAndKeepsOtherKeys() = runBlocking {
+        val browser = createBrowser(this, headless = true, sandbox = false)
+        val tab = browser.get(sampleFile("groceries.html"))
+        tab.waitForReadyState(ReadyState.COMPLETE)
+
+        tab.setLocalStorage(mapOf("kept" to "1", "replaced" to "before"))
+        tab.setLocalStorage(mapOf("replaced" to "after"))
+
+        assertEquals(mapOf("kept" to "1", "replaced" to "after"), tab.getLocalStorage())
+
+        browser.stop()
+    }
+
+    @Test
+    fun testGetLocalStorageIsEmptyOnFreshOrigin() = runBlocking {
+        val browser = createBrowser(this, headless = true, sandbox = false)
+        val tab = browser.get(sampleFile("groceries.html"))
+        tab.waitForReadyState(ReadyState.COMPLETE)
+
+        assertTrue(tab.getLocalStorage().isEmpty())
+
+        browser.stop()
+    }
+
+    @Test
+    fun testClearLocalStorage() = runBlocking {
+        val browser = createBrowser(this, headless = true, sandbox = false)
+        val tab = browser.get(sampleFile("groceries.html"))
+        tab.waitForReadyState(ReadyState.COMPLETE)
+
+        tab.setLocalStorage(mapOf("a" to "1", "b" to "2"))
+        assertEquals(2, tab.getLocalStorage().size)
+
+        tab.clearLocalStorage()
+
+        assertTrue(tab.getLocalStorage().isEmpty())
+        assertEquals(0, tab.evaluate<Int>("window.localStorage.length"))
+
+        browser.stop()
+    }
+
     // Advanced Selection Tests
 
     @Test

--- a/opentelemetry/src/commonMain/kotlin/dev/kdriver/opentelemetry/OpenTelemetryTab.kt
+++ b/opentelemetry/src/commonMain/kotlin/dev/kdriver/opentelemetry/OpenTelemetryTab.kt
@@ -105,6 +105,16 @@ class OpenTelemetryTab(
 
     override suspend fun getContent(): String = tab.getContent()
 
+    override suspend fun getLocalStorage(): Map<String, String> = tab.getLocalStorage()
+
+    override suspend fun setLocalStorage(items: Map<String, String>) = tab.setLocalStorage(items).also {
+        Span.current().addEvent("kdriver.tab.setLocalStorage")
+    }
+
+    override suspend fun clearLocalStorage() = tab.clearLocalStorage().also {
+        Span.current().addEvent("kdriver.tab.clearLocalStorage")
+    }
+
     override suspend fun activate() = tab.activate().also {
         Span.current().addEvent("kdriver.tab.activate")
     }


### PR DESCRIPTION
Fixes #26.

Adds `Tab.getLocalStorage()` and `Tab.setLocalStorage()` as requested, plus `clearLocalStorage()` since the CDP command was right there and the pair felt incomplete without it.

## Why the generator is touched too

I could not implement this against the generated bindings as they stood. `DOMStorage.getDOMStorageItems` was declared as:

```kotlin
public data class GetDOMStorageItemsReturn(
    public val entries: List<List<Double>>,
)
```

while the protocol declares the element type as an array of **strings**:

```json
"Item": { "type": "array", "items": { "type": "string" } }
```

A local storage entry is a `["key", "value"]` pair, so decoding it into doubles throws at runtime. The command was effectively unusable as generated.

The cause is in `Poetize.kt`: the `"array"` branch of `Domain.CanBeTypeAlias.jsTypeToKType` returned `LIST.parameterizedBy(DOUBLE)` unconditionally, ignoring `items`. The `Domain.TypeOrReference` overload immediately below already resolved `items` correctly, so properties and top-level type aliases describing the same array disagreed. `Domain.Type` did not even carry `items`, so it was never parsed for top-level types.

### Blast radius

Six type aliases in the protocol are arrays. Three were wrong:

| Alias | Items | Was | Now |
|---|---|---|---|
| `DOMStorage.Item` | `string` | `List<Double>` | `List<String>` |
| `DOMSnapshot.ArrayOfStrings` | `$ref StringIndex` | `List<Double>` | `List<Int>` |
| `Target.TargetFilter` | `$ref FilterEntry` | `List<Double>` | `List<FilterEntry>` |

The other three (`DOM.Quad`, `DOMSnapshot.Rectangle`, `LayerTree.PaintProfile`) are arrays of numbers and were right by accident.

In the generated sources this surfaces as three field type changes: `DOMStorage.GetDOMStorageItemsReturn.entries`, and `DOMSnapshot`'s `attributes` and `styles`.

### Changes made

- `Domain.Type` now carries `items`, and the plugin parses it. `items` moved up to `CanBeTypeAlias` since both kinds need it.
- Both `jsTypeToKType` overloads now delegate to a shared `itemsToKType`, so the two paths cannot drift apart again.
- A referenced type is resolved against the domain it was found in rather than the referring one, so a `$ref` inside its `items` points at the right domain. This is what makes `DOMSnapshot.ArrayOfStrings` resolve to `StringIndex`.
- `boolean` was added to the item type mapping, which was missing.

⚠️ **I committed only the three resulting type changes rather than a full regeneration.** Running `generateCdp` on my machine reformats all 55 domain files (expanded imports, different indentation of the flow chains) and adds two new domains that appeared in the live spec since the last generation. None of that belongs in this PR. Regenerating on your side should produce exactly these three semantic changes plus that unrelated churn.

## The feature itself

```kotlin
tab.setLocalStorage(mapOf("token" to "abc123"))
tab.getLocalStorage()   // {token=abc123}
tab.clearLocalStorage()
```

Two notes on where this differs from the Zendriver original:

- The origin is derived with Ktor's `Url.protocolWithAuthority` instead of `"/".join(self.url.split("/", 3)[:-1])` — the upstream comment on that line is literally *"there must be a better way..."*, and since `io.ktor.http` is already imported in `DefaultTab`, there is.
- I did not port the `if self.target is None or not self.target.url: await self.wait()` guard. `DefaultTab` reads `targetInfo?.url` and fails fast with `error("target is null")`, which matches how `activate()` and `saveScreenshot()` already behave in this file. Happy to add a wait instead if you would rather it block.

`setLocalStorage` writes entries concurrently, as the original does. Keys absent from the map are left untouched, which is why `clearLocalStorage` exists.

## Tests

Four tests in `TabTest` against a real headless Chrome:

- round trip of two entries, **cross-checked with `window.localStorage.getItem` evaluated in the page**, so it proves the right origin was targeted rather than merely reading back what was written;
- overwriting one key leaves the others alone;
- a fresh origin reads back empty;
- `clearLocalStorage` empties it, verified both ways.

Mutation-checked: reverting `entries` to `List<List<Double>>` breaks compilation of `getLocalStorage` (`Map<Double, ...>` vs `Map<String, String>`), so the type fix is load-bearing rather than cosmetic.

`./gradlew jvmTest` is green (179 tests). `OpenTelemetryTab` gained the three delegating overrides, with span events on the two mutating ones, matching the existing pattern there.

Note that `./gradlew detekt` already fails on `main` for unrelated missing-documentation findings in `cdp`; none of them are in files touched here, and the CI does not run it.
